### PR TITLE
Fix missing package.json due to it might be moved to temp folder.

### DIFF
--- a/.openshift/lib/utils
+++ b/.openshift/lib/utils
@@ -8,6 +8,9 @@
 function get_node_version() {
    # read the app's package.json file
    package_json="${OPENSHIFT_REPO_DIR}/package.json"
+   if [ ! -f "$package_json" ] ; then
+     package_json="$(get_node_tmp_dir)/package.json"
+   fi
 
    # attempt to detect the desired node.js version
    engine=$(grep "\"node\"" "$package_json" | tail -n 1 | sed -e 's/^.*" *[~=<>]*[=<>]* *v*\([0-9][^" ]*\) *[^"]*".*$/\1/p;d')
@@ -36,7 +39,7 @@ function get_node_install_dir() {
 #  Returns the path to the npm binary.
 function get_npm_bin_path() {
    ver=${1:-"$(get_node_version)"}
-   echo "$(get_node_install_dir)/node-v$ver-linux-x64/bin"
+   echo "$(get_node_install_dir)node-v$ver-linux-x64/bin"
 
 }  #  End of function  get_npm_bin_path.
 


### PR DESCRIPTION
Without this fix, `.openshift/markers/NODEJS_VERSION` is necessary, due to package.json can't be found because it was moved to temp folder before npm install.
